### PR TITLE
Make call to `indexOf()` more efficient

### DIFF
--- a/src/main/java/org/plumelib/merging/JavaImportsMerger.java
+++ b/src/main/java/org/plumelib/merging/JavaImportsMerger.java
@@ -544,7 +544,7 @@ public class JavaImportsMerger extends Merger {
    * @return the last of the dotted identifiers
    */
   private static String lastIdentifier(String dottedIdentifiers) {
-    int dotPos = dottedIdentifiers.lastIndexOf(".");
+    int dotPos = dottedIdentifiers.lastIndexOf('.');
     if (dotPos == -1) {
       return dottedIdentifiers;
     } else {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Minor internal simplification in identifier handling to improve consistency/readability.
  * No functional or behavioral changes; workflows and results remain identical.
  * No configuration or compatibility impacts.
  * Performance and stability unchanged.
  * No action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->